### PR TITLE
Add tests for file synchronization and command formatting

### DIFF
--- a/test/command_test.py
+++ b/test/command_test.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from command import org_format_result, org_format_results
+def test_org_format_result():
+    result = {
+        "text": "snippet",
+        "filename": Path("note.org"),
+        "line_start": 5,
+        "context": "",
+    }
+    expected = (
+        "[[note.org::5][note.org]]\n"
+        "#+begin_quote\nsnippet\n#+end_quote"
+    )
+    assert org_format_result(result) == expected
+
+
+def test_org_format_results():
+    r1 = {"text": "foo", "filename": Path("a.org"), "line_start": 1, "context": ""}
+    r2 = {"text": "bar", "filename": Path("b.org"), "line_start": 2, "context": ""}
+    expected = f"{org_format_result(r1)}\n\n{org_format_result(r2)}"
+    assert org_format_results([r1, r2]) == expected

--- a/test/file_sync_test.py
+++ b/test/file_sync_test.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+from tempfile import TemporaryDirectory
+from pathlib import Path
+import time
+
+from chromadb import chromadb
+
+from vgrep.db import DB
+from vgrep.file_sync import FileSync
+from vgrep.fs import FS
+
+
+class DummyEmbeddingFunction:
+    def __call__(self, input):
+        return [[0.0] for _ in input]
+
+    @staticmethod
+    def name() -> str:
+        return "default"
+
+    def get_config(self):
+        return {}
+
+
+class TestFileSync(TestCase):
+    def setUp(self):
+        self.dir = TemporaryDirectory()
+        self.db_dir = TemporaryDirectory()
+        chroma_settings = chromadb.Settings(anonymized_telemetry=False)
+        client = chromadb.PersistentClient(
+            path=self.db_dir.name, settings=chroma_settings
+        )
+        collection = client.get_or_create_collection(
+            name="main", embedding_function=DummyEmbeddingFunction()
+        )
+        self.db = DB(collection)
+        self.fs = FS([Path(self.dir.name)])
+        self.sync = FileSync(self.fs, self.db)
+
+    def tearDown(self):
+        self.dir.cleanup()
+        self.db_dir.cleanup()
+
+    def test_sync_add_update_remove(self):
+        file = Path(self.dir.name) / "test.org"
+        file.write_text("hello")
+
+        # Add
+        self.sync.sync()
+        files = self.db.all_files()
+        self.assertIn(file, files)
+        first_mtime = files[file]
+
+        # Query
+        results = self.db.query("hello")
+        self.assertEqual(results[0]["filename"], file)
+        self.assertIn("hello", results[0]["text"])
+
+        # Update
+        time.sleep(1)
+        file.write_text("hello again")
+        self.sync.sync()
+        files = self.db.all_files()
+        self.assertGreater(files[file], first_mtime)
+
+        # Remove
+        file.unlink()
+        self.sync.sync()
+        self.assertNotIn(file, self.db.all_files())


### PR DESCRIPTION
## Summary
- add tests exercising FileSync sync behavior including add, query, update, and remove flows
- add tests for org-mode formatting helper functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68935284e508832b8011701f23f49fa7