### PR TITLE
feat: add manager class for simplified interface

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,16 +23,17 @@ distribution for you.
 ** Command line
 Sync the database with tracked folders or search for text:
 #+begin_src shell
-vgrep --sync
-vgrep --query "search text"
+vgrep /path/to/dir --sync --match '*.org'
+vgrep /path/to/dir --query "search text"
 #+end_src
 
 ** Library
-Interact with the index programmatically:
+Interact with the index programmatically using the ``Manager``:
 #+begin_src python
-from vgrep.db import DB
+from pathlib import Path
+from vgrep.manager import Manager
 
-# assuming ``collection`` is a ``chromadb.Collection``
-db = DB(collection)
-results = db.query("needle")
+mgr = Manager(Path("/my/notes"), file_match=lambda p: p.suffix == ".org")
+mgr.sync()
+results = mgr.query("needle")
 #+end_src

--- a/README.org
+++ b/README.org
@@ -24,7 +24,7 @@ distribution for you.
 Sync the database with tracked folders or search for text:
 #+begin_src shell
 vgrep /path/to/dir --sync --match '*.org'
-vgrep /path/to/dir --query "search text"
+vgrep /path/to/dir --query "search text" --match "*.org"
 #+end_src
 
 ** Library

--- a/command.py
+++ b/command.py
@@ -55,11 +55,12 @@ def main() -> None:
     manager = Manager(args.path, file_match=match_fn)
 
     if args.sync:
-        print("Syncing...")
+        print(f'Syncing directory {manager.directory} to db {manager.db_path}')
         manager.sync()
         print("Done.")
 
     if args.query:
+        print(f'Querying {manager.db_path} for files in directory {manager.directory}')
         print(f"Results for '{args.query}'")
         print(org_format_results(manager.query(args.query)))
 

--- a/command.py
+++ b/command.py
@@ -7,15 +7,14 @@ logic has been wrapped in ``main`` so tools like ``setuptools`` can create a
 ``console_script`` entry point.
 """
 
+import argparse
+import fnmatch
+import sys
 from pathlib import Path
 from typing import List
 
-from chromadb import chromadb
-
-from vgrep.db import DB, QueryResult
-from vgrep.file_sync import FileSync
-from vgrep.fs import FS
-from settings import parse_settings
+from vgrep.db import QueryResult
+from vgrep.manager import Manager
 
 
 def org_format_result(result: QueryResult) -> str:
@@ -30,32 +29,10 @@ def org_format_results(results: List[QueryResult]) -> str:
 
 def main() -> None:
     """Entry point for the ``vgrep`` command line tool."""
-    settings = parse_settings("./settings.json")
-
-    # set up DB
-    chroma_settings = chromadb.Settings(anonymized_telemetry=False)
-    client = chromadb.PersistentClient(
-        path=settings["db_dir"], settings=chroma_settings
-    )
-    try:
-        collection = client.get_collection(name="main")
-    except chromadb.errors.NotFoundError:
-        collection = client.create_collection(name="main")
-    db = DB(collection)
-
-    paths = map(Path, settings["sync_dirs"].keys())
-    fs = FS(paths)
-    fsync = FileSync(fs, db)
-
-    import argparse
-    import sys
-
     parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path, help="Directory to index")
     parser.add_argument(
-        "-q",
-        "--query",
-        type=str,
-        help="The search string to use for the query",
+        "-q", "--query", type=str, help="The search string to use for the query"
     )
     parser.add_argument(
         "-s",
@@ -63,16 +40,28 @@ def main() -> None:
         action="store_true",
         help="Switch to sync the vector db with the file system",
     )
+    parser.add_argument(
+        "--match", type=str, help="Glob used to match files for syncing"
+    )
     args = parser.parse_args()
+
+    match_fn = None
+    if args.match:
+        pattern = args.match
+
+        def match_fn(p: Path) -> bool:
+            return p.is_file() and fnmatch.fnmatch(p.name, pattern)
+
+    manager = Manager(args.path, file_match=match_fn)
 
     if args.sync:
         print("Syncing...")
-        fsync.sync()
+        manager.sync()
         print("Done.")
 
     if args.query:
         print(f"Results for '{args.query}'")
-        print(org_format_results(db.query(args.query)))
+        print(org_format_results(manager.query(args.query)))
 
     if not args.query and not args.sync:
         parser.print_help(sys.stderr)

--- a/test/fs_test.py
+++ b/test/fs_test.py
@@ -31,10 +31,8 @@ class TestFS(TestCase):
         bottom_org_file = NamedTemporaryFile(dir=bd.name,
                                              suffix=".org")
 
-        res = set(map(Path,
-                      map(lambda x: x.name,
-                          [bottom_org_file, top_org_file])))
+        res = {Path(top_org_file.name), Path(bottom_org_file.name)}
 
-        found_files = set(FS.all_files_recur(Path(td.name)))
-        self.assertSetEqual(found_files,
-                            res)
+        fs = FS([Path(td.name)])
+        found_files = set(fs.all_files_recur(Path(td.name)))
+        self.assertSetEqual(found_files, res)

--- a/test/manager_test.py
+++ b/test/manager_test.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from vgrep.manager import Manager
+
+
+class DummyEmbeddingFunction:
+    def __call__(self, input):
+        return [[0.0] for _ in input]
+
+    @staticmethod
+    def name() -> str:
+        return "default"
+
+    def get_config(self):
+        return {}
+
+
+class TestManager(TestCase):
+    def setUp(self):
+        self.dir = TemporaryDirectory()
+        self.db_dir = Path(self.dir.name) / "db"
+
+    def tearDown(self):
+        self.dir.cleanup()
+
+    def test_sync_and_query(self):
+        file = Path(self.dir.name) / "test.txt"
+        file.write_text("hello world")
+        m = Manager(
+            Path(self.dir.name),
+            db_path=self.db_dir,
+            embedding=DummyEmbeddingFunction(),
+        )
+        m.sync()
+        results = m.query("hello")
+        self.assertTrue(any("hello" in r["text"] for r in results))
+
+    def test_match_function(self):
+        keep = Path(self.dir.name) / "keep.txt"
+        skip = Path(self.dir.name) / "skip.md"
+        keep.write_text("hello")
+        skip.write_text("world")
+
+        def matcher(p: Path) -> bool:
+            return p.suffix == ".txt"
+
+        m = Manager(
+            Path(self.dir.name),
+            file_match=matcher,
+            db_path=self.db_dir,
+            embedding=DummyEmbeddingFunction(),
+        )
+        m.sync()
+        files = m.db.all_files()
+        self.assertIn(keep, files)
+        self.assertNotIn(skip, files)
+
+    def test_default_db_path_deterministic(self):
+        m1 = Manager(
+            Path(self.dir.name),
+            file_match=lambda p: p.suffix == ".txt",
+            embedding=DummyEmbeddingFunction(),
+        )
+        m2 = Manager(
+            Path(self.dir.name),
+            file_match=lambda p: p.suffix == ".txt",
+            embedding=DummyEmbeddingFunction(),
+        )
+        self.assertEqual(m1.db_path, m2.db_path)

--- a/vgrep/manager.py
+++ b/vgrep/manager.py
@@ -1,0 +1,64 @@
+import hashlib
+import inspect
+import tempfile
+from pathlib import Path
+from typing import Callable, Optional, Any
+
+import chromadb
+
+from vgrep.db import DB
+from vgrep.fs import FS
+from vgrep.file_sync import FileSync
+
+
+class Manager:
+    """Coordinate the filesystem, ChromaDB and syncing."""
+
+    def __init__(
+        self,
+        directory: Path,
+        file_match: Optional[Callable[[Path], bool]] = None,
+        db_path: Optional[Path] = None,
+        embedding: Any = None,
+    ) -> None:
+        self.directory = Path(directory)
+        base_match = file_match or (lambda p: p.is_file())
+        self.db_path = (
+            Path(db_path)
+            if db_path
+            else self._default_db_path(self.directory, base_match)
+        )
+        self.db_path.mkdir(parents=True, exist_ok=True)
+
+        def combined_match(p: Path) -> bool:
+            if self.db_path in p.parents or p == self.db_path:
+                return False
+            return base_match(p)
+
+        self.file_match = combined_match
+
+        chroma_settings = chromadb.Settings(anonymized_telemetry=False)
+        client = chromadb.PersistentClient(path=str(self.db_path), settings=chroma_settings)
+        collection = client.get_or_create_collection(name="main", embedding_function=embedding)
+
+        self.db = DB(collection)
+        self.fs = FS([self.directory], self.file_match)
+        self._syncer = FileSync(self.fs, self.db)
+
+    def _default_db_path(self, directory: Path, match_fn: Callable[[Path], bool]) -> Path:
+        h = hashlib.sha256()
+        h.update(directory.as_posix().encode())
+        try:
+            source = inspect.getsource(match_fn).encode()
+        except (OSError, TypeError):
+            source = repr(match_fn).encode()
+        h.update(source)
+        return Path(tempfile.gettempdir()) / f"vgrep-{h.hexdigest()}"
+
+    def sync(self) -> None:
+        """Synchronize the database with the filesystem."""
+        self._syncer.sync()
+
+    def query(self, text: str, records: int = 10):
+        """Query the database."""
+        return self.db.query(text, records)


### PR DESCRIPTION
## Summary
- add Manager wrapper for ChromaDB setup, syncing, and querying
- support file filtering via Manager and `--match` CLI option
- document and test new Manager API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689417210734832bbc2152e263bf856a