### PR TITLE
Add gitignore-style ignore support to filesystem scanning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-core",
     "langchain-text-splitters",
     "pydantic",
+    "pathspec",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,7 @@ opentelemetry-semantic-conventions==0.57b0
 orjson==3.11.1
 overrides==7.7.0
 packaging==25.0
+pathspec==0.12.1
 posthog==5.4.0
 protobuf==6.31.1
 pyasn1==0.6.1

--- a/test/fs_test.py
+++ b/test/fs_test.py
@@ -36,3 +36,40 @@ class TestFS(TestCase):
         fs = FS([Path(td.name)])
         found_files = set(fs.all_files_recur(Path(td.name)))
         self.assertSetEqual(found_files, res)
+
+    def test_ignore_patterns(self):
+        td = TemporaryDirectory()
+        env_path = Path(td.name) / ".env"
+        env_path.touch()
+        pycache = Path(td.name) / "__pycache__"
+        pycache.mkdir()
+        ignored_file = pycache / "foo.pyc"
+        ignored_file.touch()
+
+        fs = FS([Path(td.name)])
+        found_files = set(fs.all_files_recur(Path(td.name)))
+
+        self.assertNotIn(env_path, found_files)
+        self.assertNotIn(ignored_file, found_files)
+
+    def test_ignore_override_by_match(self):
+        td = TemporaryDirectory()
+        env_path = Path(td.name) / ".env"
+        env_path.touch()
+        pycache = Path(td.name) / "__pycache__"
+        pycache.mkdir()
+        pyc_file = pycache / "foo.pyc"
+        pyc_file.touch()
+
+        match_env = lambda p: p.is_file() and p.name == ".env"
+        match_pyc = lambda p: p.is_file() and p.suffix == ".pyc"
+        fs = FS(
+            [Path(td.name)],
+            file_match=lambda p: match_env(p) or match_pyc(p),
+            prune_ignored_dirs=False,
+            match_supplied=True,
+        )
+        found_files = set(fs.all_files_recur(Path(td.name)))
+
+        self.assertIn(env_path, found_files)
+        self.assertIn(pyc_file, found_files)

--- a/vgrep/fs.py
+++ b/vgrep/fs.py
@@ -1,13 +1,39 @@
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
+
+import pathspec
+
+
+DEFAULT_IGNORE_PATTERNS = [".env", "__pycache__/"]
 
 
 class FS:
     """Handles filesystem operations"""
 
-    def __init__(self, files: List[Path], file_match: Callable[[Path], bool] | None = None):
+    def __init__(
+        self,
+        files: List[Path],
+        file_match: Optional[Callable[[Path], bool]] = None,
+        ignore_file: str = ".vgrepignore",
+        prune_ignored_dirs: bool = True,
+        match_supplied: bool = False,
+    ):
         self.files = files
         self.file_match = file_match or (lambda p: p.is_file())
+        self.prune_ignored_dirs = prune_ignored_dirs
+        self.match_supplied = match_supplied
+
+        self._ignore_specs: Dict[Path, pathspec.PathSpec] = {}
+        for root in self.files:
+            patterns = list(DEFAULT_IGNORE_PATTERNS)
+            if root.is_dir():
+                for name in [".gitignore", ignore_file]:
+                    ignore_path = root / name
+                    if ignore_path.is_file():
+                        patterns.extend(ignore_path.read_text().splitlines())
+            self._ignore_specs[root] = pathspec.PathSpec.from_lines(
+                "gitwildmatch", patterns
+            )
 
     def all_files_modifications(self) -> Dict[Path, float]:
         """Returns a dict of Path -> modification time"""
@@ -16,12 +42,36 @@ class FS:
             for p in sum(map(self.all_files_recur, self.files), [])
         }
 
-    def all_files_recur(self, path: Path) -> List[Path]:
+    def _ignored(self, path: Path, root: Path) -> bool:
+        spec = self._ignore_specs.get(root)
+        if spec is None:
+            return False
+        rel = path.relative_to(root)
+        rel_str = rel.as_posix()
+        if path.is_dir():
+            rel_str += "/"
+        return spec.match_file(rel_str)
+
+    def all_files_recur(self, path: Path, root: Optional[Path] = None) -> List[Path]:
         """Returns all files in `path`"""
+        root = root or path
+
+        if self._ignored(path, root):
+            if self.match_supplied and self.file_match(path):
+                pass
+            elif path.is_dir():
+                if self.prune_ignored_dirs:
+                    return []
+            else:
+                return []
+
         if path.is_file():
             return [path] if self.file_match(path) else []
         elif path.is_dir():
-            return sum(map(self.all_files_recur, path.iterdir()), [])
+            return sum(
+                (self.all_files_recur(p, root) for p in path.iterdir()),
+                [],
+            )
         else:
             return []
 

--- a/vgrep/manager.py
+++ b/vgrep/manager.py
@@ -48,7 +48,12 @@ class Manager:
         )
 
         self.db = DB(collection)
-        self.fs = FS([self.directory], self.file_match)
+        self.fs = FS(
+            [self.directory],
+            self.file_match,
+            prune_ignored_dirs=file_match is None,
+            match_supplied=file_match is not None,
+        )
         self._syncer = FileSync(self.fs, self.db)
 
     def _default_db_path(self,


### PR DESCRIPTION
## Summary
- support gitignore-style patterns when collecting files
- skip common files like `.env` and `__pycache__`
- allow `--match` files to override ignores
- add tests for ignore behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af02a5c28c832b9e07261680b3dd43